### PR TITLE
fix: a client-provided invalid content-type is not a 500 

### DIFF
--- a/receiver/otlpreceiver/otlphttp.go
+++ b/receiver/otlpreceiver/otlphttp.go
@@ -207,7 +207,7 @@ func errorHandler(w http.ResponseWriter, r *http.Request, errMsg string, statusC
 		writeStatusResponse(w, jsEncoder, statusCode, s)
 		return
 	}
-	writeResponse(w, fallbackContentType, http.StatusInternalServerError, fallbackMsg)
+	writeStatusResponse(w, jsEncoder, statusCode, s)
 }
 
 func writeStatusResponse(w http.ResponseWriter, enc encoder, statusCode int, st *status.Status) {


### PR DESCRIPTION
fix: a client-provided invalid content-type is not a 500 